### PR TITLE
rotation using queries & call it a night.

### DIFF
--- a/R/transformations.R
+++ b/R/transformations.R
@@ -90,12 +90,12 @@ setMethod("translateElement", "SpatialDataElement",
             x$data <- y
         },
         PointFrame={
-            # TODO: any way doing this with queries?
-            # 'arrow' doesn't support '%*%' nor 'rowwise'
-            xy <- c("x", "y")
-            df <- as.data.frame(x)
-            df[xy] <- as.matrix(df[xy]) %*% R
-            x <- PointFrame(df, metadata(x), zattrs=zattrs(x))
+            x@data <- x@data %>%
+                mutate(.x=x*R[1,1], .y=y*R[1,2]) %>%
+                mutate(x=.x+.y) %>%
+                mutate(.x=x*R[2,1], .y=y*R[2,2]) %>%
+                mutate(y=.x+.y) %>%
+                select(-.x, -.y)
         })
     return(x)
 }

--- a/tests/testthat/test-transformations.R
+++ b/tests/testthat/test-transformations.R
@@ -44,9 +44,10 @@ test_that("translateElement,PointFrame", {
     expect_identical(y, p)
     t <- c(t1 <- 1, t2 <- 2)
     y <- translateElement(p, t)
+    df <- collect(y@data)
     expect_identical(dim(y), dim(p))
-    expect_identical(range(y$x), range(p$x)+t1)
-    expect_identical(range(y$y), range(p$y)+t2)
+    expect_equal(range(df$x), range(p$x)+t1)
+    expect_equal(range(df$y), range(p$y)+t2)
 })
 
 # rotation ----


### PR DESCRIPTION
`PointFrame` rotation using pointers/`arrow` queries (i.e., not loading into memory until necessary, e.g., visualization). 