### PR TITLE
fixing multiscale/check bugs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,6 @@ Suggests:
     testthat,
     DT
 Enhances:
-    patchwork,
     anndataR,
     pizzarr
 Remotes:

--- a/R/ImageArray.R
+++ b/R/ImageArray.R
@@ -16,7 +16,7 @@
 #' @examples
 #' library(SpatialData.data)
 #' dir.create(td <- tempfile())
-#' pa <- unzip_merfish_demo(td)
+#' pa <- SpatialData.data:::.unzip_merfish_demo(td)
 #' pa <- file.path(pa, "images", "rasterized")
 #' (ia <- readImage(pa))
 #'

--- a/R/ImageArray.R
+++ b/R/ImageArray.R
@@ -128,8 +128,8 @@ setMethod("[", "ImageArray", \(x, i, j, k, ..., drop=FALSE) {
     if (missing(k)) k <- TRUE else if (isFALSE(k)) k <- 0 else .check_jk(k, "k")
     ijk <- list(i, j, k)
     n <- length(data(x, NULL))
+    d <- dim(data(x))
     x@data <- lapply(seq_len(n), \(.) {
-        d <- dim(data(x, .))
         j <- if (isTRUE(j)) seq_len(d[2]) else j
         k <- if (isTRUE(k)) seq_len(d[3]) else k
         jk <- lapply(list(j, k), \(jk) {

--- a/R/PointFrame.R
+++ b/R/PointFrame.R
@@ -33,7 +33,7 @@
 #' @examples
 #' library(SpatialData.data)
 #' dir.create(tf <- tempfile())
-#' base <- unzip_merfish_demo(tf)
+#' base <- SpatialData.data:::.unzip_merfish_demo(tf)
 #' x <- file.path(base, "points", "single_molecule")
 #' (p <- readPoint(x))
 #' 

--- a/R/ShapeFrame.R
+++ b/R/ShapeFrame.R
@@ -17,7 +17,7 @@
 #' @examples
 #' library(SpatialData.data)
 #' dir.create(tf <- tempfile())
-#' base <- unzip_merfish_demo(tf)
+#' base <- SpatialData.data:::.unzip_merfish_demo(tf)
 #' y <- file.path(base, "shapes", "cells")
 #' (s <- readShape(y))
 #' plot(sf::st_as_sf(data(s)), cex=0.2)

--- a/R/read.R
+++ b/R/read.R
@@ -63,7 +63,7 @@ allp = c("session_info==1.0.0", "spatialdata==0.3.0", "spatialdata_io==0.1.7",
 #' @examples
 #' library(SpatialData.data)
 #' dir.create(tf <- tempfile())
-#' base <- unzip_merfish_demo(tf)
+#' base <- SpatialData.data:::.unzip_merfish_demo(tf)
 #' (x <- readSpatialData(base))
 NULL
 

--- a/man/ImageArray.Rd
+++ b/man/ImageArray.Rd
@@ -55,7 +55,7 @@ The `ImageArray` class
 \examples{
 library(SpatialData.data)
 dir.create(td <- tempfile())
-pa <- unzip_merfish_demo(td)
+pa <- SpatialData.data:::.unzip_merfish_demo(td)
 pa <- file.path(pa, "images", "rasterized")
 (ia <- readImage(pa))
 

--- a/man/PointFrame.Rd
+++ b/man/PointFrame.Rd
@@ -80,7 +80,7 @@ Currently defined methods (here, \code{x} is a \code{PointFrame}):
 \examples{
 library(SpatialData.data)
 dir.create(tf <- tempfile())
-base <- unzip_merfish_demo(tf)
+base <- SpatialData.data:::.unzip_merfish_demo(tf)
 x <- file.path(base, "points", "single_molecule")
 (p <- readPoint(x))
 

--- a/man/ShapeFrame.Rd
+++ b/man/ShapeFrame.Rd
@@ -58,7 +58,7 @@ The `ShapeFrame` class
 \examples{
 library(SpatialData.data)
 dir.create(tf <- tempfile())
-base <- unzip_merfish_demo(tf)
+base <- SpatialData.data:::.unzip_merfish_demo(tf)
 y <- file.path(base, "shapes", "cells")
 (s <- readShape(y))
 plot(sf::st_as_sf(data(s)), cex=0.2)

--- a/man/SpatialData.Rd
+++ b/man/SpatialData.Rd
@@ -50,8 +50,8 @@
 \alias{element,SpatialData,ANY,numeric-method}
 \alias{element,SpatialData,ANY,missing-method}
 \alias{element,SpatialData,ANY,ANY-method}
-\alias{[[<-,SpatialData,numeric,ANY,ANY-method}
-\alias{[[<-,SpatialData,character,ANY,ANY-method}
+\alias{[[<-,SpatialData,numeric,ANY-method}
+\alias{[[<-,SpatialData,character,ANY-method}
 \title{The `SpatialData` class}
 \usage{
 SpatialData(images, labels, points, shapes, tables)
@@ -88,9 +88,9 @@ SpatialData(images, labels, points, shapes, tables)
 
 \S4method{element}{SpatialData,ANY,ANY}(x, i, j)
 
-\S4method{[[}{SpatialData,numeric,ANY,ANY}(x, i) <- value
+\S4method{[[}{SpatialData,numeric,ANY}(x, i) <- value
 
-\S4method{[[}{SpatialData,character,ANY,ANY}(x, i) <- value
+\S4method{[[}{SpatialData,character,ANY}(x, i) <- value
 }
 \arguments{
 \item{images}{list of \code{\link{ImageArray}}s}

--- a/man/readSpatialData.Rd
+++ b/man/readSpatialData.Rd
@@ -58,6 +58,6 @@ Reading `SpatialData`
 \examples{
 library(SpatialData.data)
 dir.create(tf <- tempfile())
-base <- unzip_merfish_demo(tf)
+base <- SpatialData.data:::.unzip_merfish_demo(tf)
 (x <- readSpatialData(base))
 }


### PR DESCRIPTION
Just a small bug, moving dim outside of apply fixes the issue, otherwise the indices are scaled twice!

I think there is another PR that we might adapt tests based on this (#116), hence omitted here.

Related Issue #90.

Some Updates:

- [ ] Auto Detect dimensionality of each level (hence dont guess: `fac <- 2^(.-1)`). The information is likely available in `.zattrs/multiscales/datasets`