### PR TITLE
Sync shapes when dropping elements from table

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -272,6 +272,8 @@ f <- \(.) setReplaceMethod(.,
         y <- attr(x, paste0(., "s"))
         y[[i]] <- value
         attr(x, paste0(., "s")) <- y
+        if (. == "table")
+            x <- .sync_shapes_on_drop(x)
         return(x)
     })
 for (. in one) eval(f(.), parent.env(environment()))

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,3 +72,17 @@
     tables(x) <- ts
     return(x)
 }
+
+.sync_shapes_on_drop <- \(x) {
+    if (!length(shapes(x))) return(x)
+    all_nms <- instances(table(x))
+    for (i in seq_along(shapes(x))) {
+        s <- shapes(x)[[i]]
+        # check which cells still exist
+        # FIXME: I kind of doubt this always has this name. Do we have an accessor for this???
+        keep <- s[["__index_level_0__"]] %in% all_nms
+        s <- s[keep, , drop = FALSE]
+        shapes(x)[[i]] <- s
+    }
+    return(x)
+}


### PR DESCRIPTION
Currently, SpatialData includes utilities to drop elements from tables when removed from the other layers, but no utilities to drop elements from other layers when elements from tables are dropped.

This is a quick and dirty new `.sync_shapes_on_drop()` function, modelled directly after `.sync_tables_on_drop()` to address a use case needed in demos.

Eventually, the `sync...` functions should probably be refactored and all cases should be covered, but this should solve the specific issue at hand.