### PR TITLE
remove redundant validation of images

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -50,7 +50,7 @@ NULL
 #' @importFrom ZarrArray ZarrArray
 .readArray <- function(x, ...) {
     md <- read_zarr_attributes(x)
-    ps <- .get_multiscales_dataset_paths(md)
+    ps <- .get_multiscales_paths(x)
     ps <- file.path(x, as.character(ps))
     as <- lapply(ps, ZarrArray)
     list(array=as, md=md)

--- a/R/sdImage.R
+++ b/R/sdImage.R
@@ -56,41 +56,19 @@ setMethod("channels", "SpatialDataImage", \(x, ...) channels(meta(x)))
 setMethod("channels", "ANY", \(x, ...) stop("only 'images' have channels"))
 
 #' @importFrom S4Vectors isSequence
-.get_multiscales_dataset_paths <- function(za) {
-    # validate 'multiscales'
-    ms <- .check_ms(za)
-    # get & validate 'path's
-    ds <- ms[[1]]$datasets
-    ps <- vapply(ds, \(.) .$path, character(1))
+.get_multiscales_paths <- function(x) {
+    ps <- list.files(x)
     ps <- suppressWarnings(as.numeric(sort(ps, decreasing=FALSE)))
+    ps <- ps[!is.na(ps)]
     if (length(ps)) {
         qs <- seq(min(ps), max(ps))
         if (!isTRUE(all.equal(ps, qs)))
             stop("SpatialDataImage paths are ill-defined, should",
                 " be an integer sequence, e.g., 0,1,...,n")
+    } else {
+      stop("SpatialDataImage path is empty")
     }
     return(ps)
-}
-
-.check_ms <- \(za) {
-    # validate 'multiscales'
-    ms <- multiscales(za)
-    if (!is.null(ms)) {
-        # validate 'datasets' 
-        ds <- ms[[1]]$datasets
-        if (!is.null(ds)) {
-            # validate 'paths'
-            ok <- vapply(ds, \(.) !is.null(.$path), logical(1))
-            if (!all(ok))
-                stop("'SpatialDataImage' paths are ill-defined,",
-                    " no 'path' attribute under 'multiscale-datasets'")
-        } else stop(
-            "'SpatialDataImage' paths are ill-defined,",
-            " no 'datasets' attribute under 'multiscale'")
-    } else stop( 
-        "'SpatialDataImage' paths are ill-defined,",
-        " no 'multiscales' attribute under '.zattrs'")
-    return(ms)
 }
 
 .check_jk <- \(x, .) {


### PR DESCRIPTION
Check the name of the scales instead of validating SDAttrs. 

Fixes #182.