### PR TITLE
More validation for images and labels

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -107,6 +107,7 @@ setGeneric("centroids", \(x, ...) standardGeneric("centroids"))
 setGeneric("data_type", \(x, ...) standardGeneric("data_type"))
 setGeneric("geom_type", \(x, ...) standardGeneric("geom_type"))
 setGeneric("multiscales", \(x, ...) standardGeneric("multiscales"))
+setGeneric("datasets", \(x, ...) standardGeneric("datasets"))
 
 # tbl ----
 

--- a/R/read.R
+++ b/R/read.R
@@ -51,9 +51,9 @@ NULL
     # https://ngff.openmicroscopy.org/specifications/0.5/index.html#images
     # The name of the array is arbitrary with the ordering defined by
     # by the "multiscales" metadata, but is often a sequence starting at 0.
-    ps <- .validate_multiscales_paths(x, datasets(mdattr))
-    ps <- file.path(x, as.character(ps))
-    as <- lapply(ps, ZarrArray)
+    ds <- .validate_multiscales_paths(x, datasets(mdattr))
+    ds <- file.path(x, as.character(ds))
+    as <- lapply(ds, ZarrArray)
     list(array=as, mdattr=mdattr)
 }
 
@@ -61,7 +61,6 @@ NULL
 #' @export
 readImage <- function(x, ...) {
     l <- .readArray(x, ...)
-    # SpatialDataImage(data=l$array, meta=SpatialDataAttrs(l$md), ...)
     SpatialDataImage(data=l$array, meta=l$mdattr, ...)
 }
 
@@ -69,7 +68,6 @@ readImage <- function(x, ...) {
 #' @export
 readLabel <- function(x, ...) {
     l <- .readArray(x, ...)
-    # SpatialDataLabel(data=l$array, meta=SpatialDataAttrs(l$md), ...)
     SpatialDataLabel(data=l$array, meta=l$mdattr, ...)
 }
 

--- a/R/read.R
+++ b/R/read.R
@@ -46,24 +46,31 @@ NULL
 #' @importFrom ZarrArray ZarrArray
 .readArray <- function(x, ...) {
     md <- read_zarr_attributes(x)
-    ps <- .get_multiscales_paths(x)
+    mdattr <- SpatialDataAttrs(md)
+    # TODO: paths to datasets have to be validated properly in the future
+    # https://ngff.openmicroscopy.org/specifications/0.5/index.html#images
+    # The name of the array is arbitrary with the ordering defined by
+    # by the "multiscales" metadata, but is often a sequence starting at 0.
+    ps <- .validate_multiscales_paths(x, datasets(mdattr))
     ps <- file.path(x, as.character(ps))
     as <- lapply(ps, ZarrArray)
-    list(array=as, md=md)
+    list(array=as, mdattr=mdattr)
 }
 
 #' @rdname readSpatialData
 #' @export
 readImage <- function(x, ...) {
     l <- .readArray(x, ...)
-    SpatialDataImage(data=l$array, meta=SpatialDataAttrs(l$md), ...)
+    # SpatialDataImage(data=l$array, meta=SpatialDataAttrs(l$md), ...)
+    SpatialDataImage(data=l$array, meta=l$mdattr, ...)
 }
 
 #' @rdname readSpatialData
 #' @export
 readLabel <- function(x, ...) {
     l <- .readArray(x, ...)
-    SpatialDataLabel(data=l$array, meta=SpatialDataAttrs(l$md), ...)
+    # SpatialDataLabel(data=l$array, meta=SpatialDataAttrs(l$md), ...)
+    SpatialDataLabel(data=l$array, meta=l$mdattr, ...)
 }
 
 #' @rdname readSpatialData

--- a/R/sdArray.R
+++ b/R/sdArray.R
@@ -150,10 +150,10 @@ setMethod("channels", "SpatialDataElement", \(x, ...) stop("only 'images' have c
 #' @importFrom S4Vectors isSequence
 .validate_multiscales_paths <- function(x, ds) {
     ps <- list.files(x)
-    ps <- ps[ps %in% ds]
-    if (!length(ps))
+    ds <- ds[ds %in% ps]
+    if (!length(ds))
       stop("Invalid SpatialData image or label: metadata does not match the names of Zarr arrays")
-    return(ps)
+    return(ds)
 }
 
 # sub ----

--- a/R/sdArray.R
+++ b/R/sdArray.R
@@ -146,19 +146,13 @@ setMethod("channels", "SpatialDataImage", \(x, ...) channels(meta(x)))
 #' @rdname SpatialDataArray
 setMethod("channels", "SpatialDataElement", \(x, ...) stop("only 'images' have channels"))
 
+# compares metadata dataset paths to arrays on disk
 #' @importFrom S4Vectors isSequence
-.get_multiscales_paths <- function(x) {
+.validate_multiscales_paths <- function(x, ds) {
     ps <- list.files(x)
-    ps <- suppressWarnings(as.numeric(sort(ps, decreasing=FALSE)))
-    ps <- ps[!is.na(ps)]
-    if (length(ps)) {
-        qs <- seq(min(ps), max(ps))
-        if (!isTRUE(all.equal(ps, qs)))
-            stop("SpatialDataImage paths are ill-defined, should",
-                " be an integer sequence, e.g., 0,1,...,n")
-    } else {
-      stop("SpatialDataImage path is empty")
-    }
+    ps <- ps[ps %in% ds]
+    if (!length(ps))
+      stop("Invalid SpatialData image or label: metadata does not match the names of Zarr arrays")
     return(ps)
 }
 

--- a/R/sdAttrs.R
+++ b/R/sdAttrs.R
@@ -142,6 +142,14 @@ setMethod("$", "SpatialDataAttrs", \(x, name) x[[name]])
 #' @noRd 
 setMethod("multiscales", "list", .ms)
 
+# internal use only!
+#' @noRd 
+setMethod("datasets", "list", \(x, ...) {
+  vapply(multiscales(x)[[1]]$datasets, \(.){
+    .$path
+  }, character(1))
+})
+
 # features ----
 
 #' @export


### PR DESCRIPTION
These changes make sure that the zarr arrays in the SpatialData stores of images and labels have the same names as indicated in the multiscales metadata. 