### PR TITLE
Customize pkgdown website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -92,6 +92,6 @@ Remotes:
 License: Artistic-2.0
 Encoding: UTF-8
 VignetteBuilder: knitr
-URL: https://github.com/HelenaLC/SpatialData
+URL: https://helenalc.github.io/SpatialData/, https://github.com/HelenaLC/SpatialData
 BugReports: https://github.com/HelenaLC/SpatialData/issues
 Config/roxygen2/version: 8.0.0

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,15 @@
+url: https://helenalc.github.io/SpatialData
+template:
+  bootstrap: 5
+
+reference:
+  - title: "Read SpatialData"
+    contents:
+      - starts_with("read")
+  - title: "Methods for SpatialData objects or their components"
+    contents:
+      - -starts_with("read")
+      - -blobs
+  - title: "Example datasets"
+    contents:
+      - blobs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,16 @@ url: https://helenalc.github.io/SpatialData
 template:
   bootstrap: 5
 
+navbar:
+  structure:
+    left:  [intro, reference, articles, demos, news]
+    right: [search, github, lightswitch]
+  components:
+    demos:
+      text: Demos
+      href: https://helenalc.github.io/SpatialData.demo/
+      aria-label: Demos
+
 reference:
   - title: "Read SpatialData"
     contents:


### PR DESCRIPTION
- Added links in DESCRIPTION for discoverability and proper cross-site linking
- Added a reference index so that functions are not all lumped together in the reference index. See https://ggplot2.tidyverse.org/reference/index.html for an example of a really nice reference index
- Added a link to the demos in the navbar for users who would like to see longer, more complex and more realistic use cases